### PR TITLE
Update agent handshake key configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,10 @@ ADMIN_PASSWORD=your_admin_password
 ADMIN_EMAIL=your_admin_email@example.com
 
 # WINDOWS EXPORTER
-export HANDSHAKE_KEY=your_secret_key
+# Основная переменная для ключа рукопожатия агента
+AGENT_HANDSHAKE_KEY=your_secret_key
+# Оставьте HANDSHAKE_KEY для совместимости со старыми конфигурациями
+HANDSHAKE_KEY=your_secret_key
 
 # PROMETHEUS
 PROMETHEUS_PROXY_URL=http://nginx-proxy:8080

--- a/README.ru.md
+++ b/README.ru.md
@@ -157,7 +157,7 @@ docker-compose --version
         - `TELEGRAM_BOT_TOKEN`: токен вашего Telegram бота (получите у @BotFather)
         - `TELEGRAM_CHAT_ID` и `ADMIN_TELEGRAM_CHAT_ID`: ID чата для получения уведомлений
         - `ADMIN_USERNAME`, `ADMIN_PASSWORD` и `ADMIN_EMAIL`: учетные данные администратора
-        - `HANDSHAKE_KEY`: секретный ключ для агентов (придумайте сложный)
+        - `AGENT_HANDSHAKE_KEY`: секретный ключ для агентов (придумайте сложный). При необходимости можно также задать `HANDSHAKE_KEY` для совместимости со старыми конфигурациями.
         - `PROMETHEUS_AUTH_PASSWORD`: пароль для доступа к Prometheus
         - Настройки SMTP для отправки email-уведомлений:
             - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`

--- a/services/network-scanner/network-scanner.service.ts
+++ b/services/network-scanner/network-scanner.service.ts
@@ -146,10 +146,12 @@ export class NetworkScannerService {
 				.get(`http://${ip}:${options.agentPort}/metrics`, {
 					timeout: options.timeout,
 					proxy: false,
-					headers: {
-						'X-Agent-Handshake-Key':
-							process.env.AGENT_HANDSHAKE_KEY || 'VERY_SECRET_KEY'
-					}
+                                        headers: {
+                                                'X-Agent-Handshake-Key':
+                                                        process.env.HANDSHAKE_KEY ??
+                                                        process.env.AGENT_HANDSHAKE_KEY ??
+                                                        'VERY_SECRET_KEY'
+                                        }
 				})
 				.catch(error => {
 					// Детальное логирование ошибки


### PR DESCRIPTION
## Summary
- read the agent handshake header from HANDSHAKE_KEY with a fallback to AGENT_HANDSHAKE_KEY for compatibility
- refresh the example environment file to use AGENT_HANDSHAKE_KEY and document the legacy HANDSHAKE_KEY option
- update the Russian README to mention the new variable name and compatibility guidance

## Testing
- yarn lint *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68cc20e0e68c83339bc7301d3d95e349